### PR TITLE
Allow reuse as component without app entrypoint

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,8 +5,13 @@ set(COMPONENT_SRCS
     "SWO.c"
     "SW_DP.c"
     "UART.c"
-    "cmsis_dap_tcp.c"
-    "main.c")
+    "cmsis_dap_tcp.c")
+
+# Include the app entrypoint only for the standalone firmware project, so
+# other ESP-IDF projects can consume this directory as a component.
+if(CMAKE_PROJECT_NAME STREQUAL "cmsis_dap_tcp_esp32")
+    list(APPEND COMPONENT_SRCS "main.c")
+endif()
 
 if(CONFIG_ESP_UART_BRIDGE_ENABLED)
     list(APPEND COMPONENT_SRCS "uart_bridge.c")

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -29,4 +29,4 @@ idf_component_register(SRCS ${COMPONENT_SRCS}
                        REQUIRES esp_timer
                        REQUIRES esp_wifi
                        REQUIRES nvs_flash
-                       INCLUDE_DIRS "")
+                       INCLUDE_DIRS ".")


### PR DESCRIPTION
Hi - I'm a human ;) 

I came across your project when attempting to figure out how to remotely flash my jtag devices... I like it - works great.

In an effort to reduce the footprint of devices i have to maintain across my house, i try to keep esp32's running esphome whenever possible. I'm building a wrapper for your project that allows folks to add the functionality of your project to any esphome device.  https://github.com/w531t4/ESPHome-cmsis_dap_tcp_esp32-Wrapper

PR Intent: Allow other projects to leverage functionality as components without disrupting existing functionality. Accomplished this by masking main unless someone is building the project natively. 

Testing: After making the change, i built the library (idf.py build flash) and it built, uploaded to the esp32, and facilitated remote jtagging with openocd successfully. 

Glad to make further adjustments if needed!

Aaron



