### PR TITLE
Fix nTRST Kconfig guard

### DIFF
--- a/main/DAP_config.h
+++ b/main/DAP_config.h
@@ -58,7 +58,7 @@
 #define GPIO_TDO                CONFIG_ESP_DAP_GPIO_TDO
 #endif
 
-#ifdef CONFIG_ESP_DAP_NTRST_SUPPORTED
+#ifdef CONFIG_ESP_DAP_JTAG_NTRST_SUPPORTED
 #define GPIO_NTRST              CONFIG_ESP_DAP_GPIO_NTRST
 #endif
 


### PR DESCRIPTION
Hi again!

While building the wrapper and ensuring ntrst functionality worked, i came across this build flag (CONFIG_ESP_DAP_NTRST_SUPPORTED) that appears to be mismatched and should be (CONFIG_ESP_DAP_JTAG_NTRST_SUPPORTED). CONFIG_ESP_DAP_JTAG_NTRST_SUPPORTED is in sdkconfig, CONFIG_ESP_DAP_NTRST_SUPPORTED is not.

Code compiles successfully with the fix (and ntrst works now, too).